### PR TITLE
스터디 개설 API 수정, 스터디 삭제 API 개발

### DIFF
--- a/backend/src/main/java/tayo/sseuktudy/controller/StudyController.java
+++ b/backend/src/main/java/tayo/sseuktudy/controller/StudyController.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import tayo.sseuktudy.dto.study.StudyDeleteDto;
 import tayo.sseuktudy.dto.study.StudyModifyDto;
 import tayo.sseuktudy.dto.study.StudyRegistDto;
 import tayo.sseuktudy.service.study.StudyService;
@@ -56,6 +57,26 @@ public class StudyController {
         logger.info("스터디 수정 요청");
 
         int result = studyService.modifyStudy(studyModifyDto); // 스터디 테이블에 집어넣기
+
+        if(result == 0){
+            resultMap.put("message", "FAIL");
+            status = HttpStatus.INTERNAL_SERVER_ERROR;
+        }else{
+            resultMap.put("message", "SUCCESS");
+            status = HttpStatus.ACCEPTED;
+        }
+
+        return new ResponseEntity<Map<String, Object>>(resultMap, status);
+    }
+
+    @DeleteMapping("/study")
+    public ResponseEntity<Map<String, Object>> deleteStudy(@RequestBody StudyDeleteDto studyDeleteDto){
+        Map<String, Object> resultMap = new HashMap<>();
+
+        HttpStatus status = null;
+        logger.info("스터디 삭제 요청");
+
+        int result = studyService.deleteStudy(studyDeleteDto);
 
         if(result == 0){
             resultMap.put("message", "FAIL");

--- a/backend/src/main/java/tayo/sseuktudy/controller/StudyController.java
+++ b/backend/src/main/java/tayo/sseuktudy/controller/StudyController.java
@@ -47,7 +47,6 @@ public class StudyController {
 
         return new ResponseEntity<Map<String, Object>>(resultMap, status);
     }
-<<<<<<< F04_BE_정현명
 
     @PutMapping("/study")
     public ResponseEntity<Map<String, Object>> modifyStudy(@RequestBody StudyModifyDto studyModifyDto){
@@ -68,6 +67,4 @@ public class StudyController {
 
         return new ResponseEntity<Map<String, Object>>(resultMap, status);
     }
-=======
->>>>>>> back
 }

--- a/backend/src/main/java/tayo/sseuktudy/dto/study/StudyDeleteDto.java
+++ b/backend/src/main/java/tayo/sseuktudy/dto/study/StudyDeleteDto.java
@@ -1,0 +1,11 @@
+package tayo.sseuktudy.dto.study;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class StudyDeleteDto {
+    String userId;
+    int studyId;
+}

--- a/backend/src/main/java/tayo/sseuktudy/dto/study/StudyJoinDto.java
+++ b/backend/src/main/java/tayo/sseuktudy/dto/study/StudyJoinDto.java
@@ -1,0 +1,12 @@
+package tayo.sseuktudy.dto.study;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class StudyJoinDto {
+    String userId;
+    int studyId;
+    String userStatus;
+}

--- a/backend/src/main/java/tayo/sseuktudy/mapper/StudyMapper.java
+++ b/backend/src/main/java/tayo/sseuktudy/mapper/StudyMapper.java
@@ -2,6 +2,7 @@ package tayo.sseuktudy.mapper;
 
 import org.apache.ibatis.annotations.Mapper;
 import tayo.sseuktudy.dto.study.StudyInfoDto;
+import tayo.sseuktudy.dto.study.StudyJoinDto;
 import tayo.sseuktudy.dto.study.StudyModifyDto;
 import tayo.sseuktudy.dto.study.StudyRegistDto;
 
@@ -12,6 +13,7 @@ public interface StudyMapper {
 
     public int registStudy(StudyRegistDto studyRegistDto);
 
+    public int joinStudy(StudyJoinDto studyJoinDto);
     public int modifyStudy(StudyModifyDto studyModifyDto);
 //    public StudyInfoDto getStudyInfo()
 

--- a/backend/src/main/java/tayo/sseuktudy/mapper/StudyMapper.java
+++ b/backend/src/main/java/tayo/sseuktudy/mapper/StudyMapper.java
@@ -1,10 +1,7 @@
 package tayo.sseuktudy.mapper;
 
 import org.apache.ibatis.annotations.Mapper;
-import tayo.sseuktudy.dto.study.StudyInfoDto;
-import tayo.sseuktudy.dto.study.StudyJoinDto;
-import tayo.sseuktudy.dto.study.StudyModifyDto;
-import tayo.sseuktudy.dto.study.StudyRegistDto;
+import tayo.sseuktudy.dto.study.*;
 
 import java.util.Optional;
 
@@ -15,6 +12,8 @@ public interface StudyMapper {
 
     public int joinStudy(StudyJoinDto studyJoinDto);
     public int modifyStudy(StudyModifyDto studyModifyDto);
+    public int deleteStudy(StudyDeleteDto studyDeleteDto);
+
 //    public StudyInfoDto getStudyInfo()
 
 }

--- a/backend/src/main/java/tayo/sseuktudy/service/study/StudyService.java
+++ b/backend/src/main/java/tayo/sseuktudy/service/study/StudyService.java
@@ -1,5 +1,6 @@
 package tayo.sseuktudy.service.study;
 
+import tayo.sseuktudy.dto.study.StudyDeleteDto;
 import tayo.sseuktudy.dto.study.StudyModifyDto;
 import tayo.sseuktudy.dto.study.StudyRegistDto;
 
@@ -8,4 +9,5 @@ import java.util.Optional;
 public interface StudyService {
     public int registStudy(StudyRegistDto studyRegistDto);
     public int modifyStudy(StudyModifyDto studyModifyDto);
+    public int deleteStudy(StudyDeleteDto studyDeleteDto);
 }

--- a/backend/src/main/java/tayo/sseuktudy/service/study/StudyServiceImpl.java
+++ b/backend/src/main/java/tayo/sseuktudy/service/study/StudyServiceImpl.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import tayo.sseuktudy.dto.question.QuestionModifyDto;
 import tayo.sseuktudy.dto.question.QuestionRegistDto;
+import tayo.sseuktudy.dto.study.StudyDeleteDto;
 import tayo.sseuktudy.dto.study.StudyJoinDto;
 import tayo.sseuktudy.dto.study.StudyModifyDto;
 import tayo.sseuktudy.dto.study.StudyRegistDto;
@@ -48,7 +49,7 @@ public class StudyServiceImpl implements StudyService{
 
         studyJoinDto.setStudyId(studyRegistDto.getStudyId());
         studyJoinDto.setUserId(studyRegistDto.getStudyLeaderId());
-        studyJoinDto.setUserStatus("leader");
+        studyJoinDto.setUserStatus("member");
 
         if(studyMapper.joinStudy(studyJoinDto) != 1){
             return 0;
@@ -73,4 +74,10 @@ public class StudyServiceImpl implements StudyService{
 
         return studyMapper.modifyStudy(studyModifyDto);
     }
+
+    @Override
+    public int deleteStudy(StudyDeleteDto studyDeleteDto) {
+        return studyMapper.deleteStudy(studyDeleteDto);
+    }
+
 }

--- a/backend/src/main/java/tayo/sseuktudy/service/study/StudyServiceImpl.java
+++ b/backend/src/main/java/tayo/sseuktudy/service/study/StudyServiceImpl.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import tayo.sseuktudy.dto.question.QuestionModifyDto;
 import tayo.sseuktudy.dto.question.QuestionRegistDto;
+import tayo.sseuktudy.dto.study.StudyJoinDto;
 import tayo.sseuktudy.dto.study.StudyModifyDto;
 import tayo.sseuktudy.dto.study.StudyRegistDto;
 import tayo.sseuktudy.mapper.QuestionMapper;
@@ -42,6 +43,17 @@ public class StudyServiceImpl implements StudyService{
                 return 0;
             }
         }
+
+        StudyJoinDto studyJoinDto = new StudyJoinDto();
+
+        studyJoinDto.setStudyId(studyRegistDto.getStudyId());
+        studyJoinDto.setUserId(studyRegistDto.getStudyLeaderId());
+        studyJoinDto.setUserStatus("leader");
+
+        if(studyMapper.joinStudy(studyJoinDto) != 1){
+            return 0;
+        }
+
         return 1;
     }
 

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -4,7 +4,7 @@ server.port=9999
 spring.datasource.hikari.maximum-pool-size=4
 
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.datasource.url=jdbc:mysql://ec2-34-199-120-230.compute-1.amazonaws.com:3306/sseuktudy?serverTimezone=UTC&useUniCode=yes&characterEncoding=UTF-8
+spring.datasource.url=jdbc:mysql://localhost:3306/sseuktudy?serverTimezone=UTC&useUniCode=yes&characterEncoding=UTF-8
 spring.datasource.username=ssafy
 spring.datasource.password=ssafy
 

--- a/backend/src/main/resources/mapper/study.xml
+++ b/backend/src/main/resources/mapper/study.xml
@@ -7,6 +7,12 @@
             value (#{studyTitle}, #{studyLeaderId}, #{studyStatus}, #{studyIntroduction}, #{studyStartdate}, #{studyEnddate}, #{studyGoals}, #{studyType}, #{studyUserMin}, #{studyUserMax},#{studyContent}, #{studyPlace},#{studyCategoryId}, #{studyView});
     </insert>
 
+    <insert id="joinStudy" parameterType="StudyJoinDto">
+        insert into user_join_study (user_id, study_id, user_status)
+            value (#{userId}, #{studyId}, #{userStatus})
+    </insert>
+
+
     <update id="modifyStudy" parameterType="StudyModifyDto">
         update study set study_title = #{studyTitle}, study_leader_id= #{studyLeaderId}, study_status = #{studyStatus}, study_introduction = #{studyIntroduction}, study_startdate = #{studyStartdate},
         study_enddate = #{studyEnddate}, study_goals = #{studyGoals}, study_type = #{studyType}, study_user_min = #{studyUserMin}, study_user_max = #{studyUserMax}, study_content = #{studyContent},

--- a/backend/src/main/resources/mapper/study.xml
+++ b/backend/src/main/resources/mapper/study.xml
@@ -20,4 +20,9 @@
         where study_id = #{studyId}
     </update>
 
+    <delete id="deleteStudy" parameterType="StudyDeleteDto">
+        delete from study
+        where study_id=#{studyId}
+    </delete>
+
 </mapper>


### PR DESCRIPTION
## :bookmark_tabs: 제목

fix : 스터디 개설 API에 스터디 리더를 스터디원으로 추가하는 기능 추가
feat : 스터디 삭제 API 개발, 테스트 완료

## :paperclip: 관련 이슈

- #41 

## :heavy_check_mark: 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 스터디 개설 API에 스터디 리더를 스터디원으로 추가하는 기능 추가

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- application.properties 에 mysql로 다시 바꿨어요 테스트하느라
- 그 외래키 관련 db에서 설정해서 배포한걸로 테스트 하려면 db 또 수정해야 할듯 제가 수정할 수 있는 방법 알려주시면 개발하면서 수정할 수 있을텐데 
- 스터디만 삭제했을 때 관련 테이블 삭제되는 거 확인했습니다. ( 스터디원 테이블, 사전질문 테이블 )

## 🕰 실제 소요 시간

> 작업을 시작하기 부터 PR을 올리기 까지 소요된 시간입니다.

- (2시간)
