### PR TITLE
fix : 스터디에 스터디장만 있을 경우 스터디원 조회가 안되는 오류 수정, 스터디원 정보 조회 수정

### DIFF
--- a/backend/src/main/java/tayo/sseuktudy/controller/MemberController.java
+++ b/backend/src/main/java/tayo/sseuktudy/controller/MemberController.java
@@ -70,8 +70,8 @@ public class MemberController {
         return new ResponseEntity<>(resultMap, status);
     }
 
-    @GetMapping("/member/list/{studyId}")
-    public ResponseEntity<Map<String, Object>> getMembers(@PathVariable int studyId, HttpServletRequest request){
+    @GetMapping("/member/list")
+    public ResponseEntity<Map<String, Object>> getMembers(@RequestParam int studyId, HttpServletRequest request){
         logger.info("스터디 멤버 전체조회 API 실행");
         Map<String, Object> resultMap = new HashMap<>();
         HttpStatus status = HttpStatus.UNAUTHORIZED;

--- a/backend/src/main/resources/mapper/member.xml
+++ b/backend/src/main/resources/mapper/member.xml
@@ -10,9 +10,9 @@
     <select id="getMembers" parameterType="int" resultType="MemberInfoDto">
         select ujs.user_id userId, ujs.study_id studyId, ujs.user_status userStatus, ujs.user_introduction userIntroduction, ujs.user_nickname userNickname, q.question_id questionId , q.question_content questionContent, uaq.question_answer questionAnswer
         from user_join_study ujs
-                 right join question q
+                 left join question q
                             on ujs.study_id = q.study_id
-                 right join user_answer_question uaq
+                 left join user_answer_question uaq
                             on q.question_id = uaq.question_id
         where ujs.study_id = #{studyId}
         order by ujs.user_id, q.question_id;


### PR DESCRIPTION
## :bookmark_tabs: 제목

(작업 내역 한줄로 요약)
(작업 내역 확인하기 편하도록 gif 첨부)

스터디원과 사전질문, 사전질문 답변 테이블을 조인하는 과정에서 
사전질문쪽으로 조인 (right join)하다 보니 사전질문 답변이 없는 스터디원(스터디 리더)이 조회가 안되는 버그 발생
left join으로 변경

스터디원 전체 조회 API에서 @PathVariable을 @RequestParam으로 변경

## :paperclip: 관련 이슈

- #68 

## :heavy_check_mark: 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] Test Code를 작성하였나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 스터디원 전체조회 API 수정

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점


## 🕰 실제 소요 시간

> 작업을 시작하기 부터 PR을 올리기 까지 소요된 시간입니다.

- (0.5시간)
