### PR TITLE
feat : 스터디 상세조회 API 호출 시 조회수 증가기능 추가 , studyId 바인딩 안되던 것 수정

### DIFF
--- a/backend/src/main/java/tayo/sseuktudy/mapper/StudyMapper.java
+++ b/backend/src/main/java/tayo/sseuktudy/mapper/StudyMapper.java
@@ -18,6 +18,7 @@ public interface StudyMapper {
     public List<StudyInfoDto> getStudyByUserId(StudyUserFilterDto studyUserFilterDto);
     public int getStudyCntByFilter(StudyFilterDto studyFilterDto);
     public StudyInfoDto getStudyByStudyId(int studyId);
+    public int raiseStudyView(int studyId);
     public int likeStudy(StudyUserIdDto studyUserIdDto);
     public int leaderCheck(StudyUserIdDto studyUserIdDto);
 

--- a/backend/src/main/java/tayo/sseuktudy/service/study/StudyServiceImpl.java
+++ b/backend/src/main/java/tayo/sseuktudy/service/study/StudyServiceImpl.java
@@ -95,8 +95,10 @@ public class StudyServiceImpl implements StudyService{
         return studyMapper.getStudyByUserId(studyUserFilterDto);
     }
 
+    @Transactional
     @Override
     public StudyDetailDto getStudyByStudyId(int studyId) {
+        studyMapper.raiseStudyView(studyId);
         StudyInfoDto studyInfoDto = studyMapper.getStudyByStudyId(studyId);
         List<CommentInfoDto> commentInfoList = commentMapper.listComment(studyId);
 
@@ -121,6 +123,9 @@ public class StudyServiceImpl implements StudyService{
                 }
             }
         }
+
+
+
         StudyDetailDto studyDetailDto = new StudyDetailDto();
         studyDetailDto.setStudyInfoDto(studyInfoDto);
         studyDetailDto.setCommentInfoList(result);

--- a/backend/src/main/resources/mapper/comment.xml
+++ b/backend/src/main/resources/mapper/comment.xml
@@ -8,7 +8,7 @@
             value (#{userId}, #{studyId},#{commentDetail}, now(), #{upCommentId});
     </insert>
     <select id="listComment" parameterType="int" resultType="CommentInfoDto">
-        select comment_id commentId, user_id userId, (select user_nickname from user where user_id = userId)
+        select study_id studyId, comment_id commentId, user_id userId, (select user_nickname from user where user_id = userId)
                     userNickname, comment_detail commentDetail, regist_time registTime, modify_time modifyTime, up_comment_id upCommentId
         from comment where study_id = #{studyId};
     </select>

--- a/backend/src/main/resources/mapper/study.xml
+++ b/backend/src/main/resources/mapper/study.xml
@@ -108,7 +108,7 @@
     </select>
 
     <select id="getStudyByStudyId" parameterType="int" resultType="StudyInfoDto">
-        select s.study_id studyId, study_title studyTitle, study_leader_id studyLeaderId, study_status studyStatus, study_introduction studyIntroduction, study_startdate studyStartdate,
+        select s.study_id studyId, study_title studyTitle, study_leader_id studyLeaderId, study_status studyStatus, study_introduction studyIntroduction, study_startdate studyStartdate, study_view studyView,
                study_enddate studyEnddate, study_registdate studyRegistdate, study_goals studyGoals, study_type studyType , study_user_min studyUserMin, study_user_max studyUserMax, study_content studyContent,
                study_place studyPlace, study_category_id studyCategoryId, count(uls.study_id) as studyLike
         from study s
@@ -116,6 +116,12 @@
         where s.study_id = #{studyId}
         group by s.study_id
     </select>
+
+    <update id="raiseStudyView" parameterType="int">
+        update study
+        set study_view = study_view+1
+        where study_id = #{studyId}
+    </update>
 
     <insert id="likeStudy" parameterType="StudyUserIdDto">
         insert into user_like_study(user_id, study_id)


### PR DESCRIPTION
## :bookmark_tabs: 제목

(작업 내역 한줄로 요약)
(작업 내역 확인하기 편하도록 gif 첨부)

![image](https://user-images.githubusercontent.com/67681207/177679747-bac6a1e7-63fe-4b26-a3dc-9c2a1dd4403c.png)



## :paperclip: 관련 이슈

- #41 

## :heavy_check_mark: 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] Test Code를 작성하였나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 자식 댓글에 studyId 바인딩 안되서 부모 id가 0으로 나오던 것 수정
- [x] 조회 수 올리는 기능 추가

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점



## 🕰 실제 소요 시간

> 작업을 시작하기 부터 PR을 올리기 까지 소요된 시간입니다.

- (1시간)
